### PR TITLE
chore: convert to es6

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ```javascript
 // Imports the Google Cloud client library
-const Resource = require('@google-cloud/resource');
+const {Resource} = require('@google-cloud/resource');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-node": "^7.0.0",
     "eslint-plugin-prettier": "^2.3.1",
-    "google-auto-auth": "^0.10.0",
     "gts": "^0.8.0",
     "ink-docstrap": "^1.3.0",
     "intelli-espower-loader": "^1.0.1",

--- a/samples/projects.js
+++ b/samples/projects.js
@@ -18,7 +18,7 @@
 function listProjects() {
   // [START resource_list_projects]
   // Imports the Google Cloud client library
-  const Resource = require('@google-cloud/resource');
+  const {Resource} = require('@google-cloud/resource');
 
   // Creates a client
   const resource = new Resource();

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -17,7 +17,7 @@
 
 // [START resource_quickstart]
 // Imports the Google Cloud client library
-const Resource = require('@google-cloud/resource');
+const {Resource} = require('@google-cloud/resource');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -16,10 +16,12 @@
 'use strict';
 
 const proxyquire = require(`proxyquire`).noPreserveCache();
-const resource = proxyquire(`@google-cloud/resource`, {})();
+const Resource = proxyquire(`@google-cloud/resource`, {}).Resource;
 const sinon = require(`sinon`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
+
+const resource = new Resource();
 
 test.before(tools.stubConsole);
 test.after.always(tools.restoreConsole);
@@ -29,7 +31,6 @@ test.cb(`should list projects`, t => {
     getProjects: () => {
       return resource.getProjects().then(([projects]) => {
         t.true(Array.isArray(projects));
-
         setTimeout(() => {
           try {
             t.true(console.log.called);
@@ -49,6 +50,8 @@ test.cb(`should list projects`, t => {
   };
 
   proxyquire(`../quickstart`, {
-    '@google-cloud/resource': sinon.stub().returns(resourceMock),
+    '@google-cloud/resource': {
+      Resource: sinon.stub().returns(resourceMock),
+    },
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,7 @@ import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as is from 'is';
-import * as util from 'util';
-
-var Project = require('./project.js');
+import {Project} from './project';
 
 /**
  * @typedef {object} ClientConfig
@@ -68,7 +66,7 @@ var Project = require('./project.js');
  * @param {ClientConfig} [options] Configuration options.
  *
  * @example <caption>Import the client library</caption>
- * const Resource = require('@google-cloud/resource');
+ * const {Resource} = require('@google-cloud/resource');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const resource = new Resource();
@@ -83,297 +81,286 @@ var Project = require('./project.js');
  * region_tag:resource_quickstart
  * Full quickstart example:
  */
-function Resource(options) {
-  options = options || {};
+class Resource extends Service {
+  getProjectsStream;
+  constructor(options?) {
+    options = options || {};
+    var config = {
+      baseUrl: 'https://cloudresourcemanager.googleapis.com/v1',
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      projectIdRequired: false,
+      packageJson: require('../../package.json'),
+    };
+    super(config, options);
 
-  var config = {
-    baseUrl: 'https://cloudresourcemanager.googleapis.com/v1',
-    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-    projectIdRequired: false,
-    packageJson: require('../../package.json'),
+    /**
+     * Get a list of {@link Resource/project} objects as a readable object stream.
+     *
+     * @param {object} query Configuration object. See
+     *     {@link Resource#getProjects} for a complete list of options.
+     * @return {stream}
+     *
+     * @example
+     * const {Resource} = require('@google-cloud/resource');
+     * const resource = new Resource();
+     *
+     * resource.getProjectsStream()
+     *   .on('error', console.error)
+     *   .on('data', function(project) {
+     *     // `project` is a `Project` object.
+     *   })
+     *   .on('end', function() {
+     *     // All projects retrieved.
+     *   });
+     *
+     * //-
+     * // If you anticipate many results, you can end a stream early to prevent
+     * // unnecessary processing and API requests.
+     * //-
+     * resource.getProjectsStream()
+     *   .on('data', function(project) {
+     *     this.end();
+     *   });
+     */
+    this.getProjectsStream = paginator.streamify(
+      'getProjects'
+    );
+  }
+
+  /**
+   * Create a project.
+   *
+   * **This method only works if you are authenticated as yourself, e.g. using the
+   * gcloud SDK.**
+   *
+   * @see [Projects Overview]{@link https://cloud.google.com/compute/docs/networking#networks}
+   * @see [projects: create API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/create}
+   *
+   * @param {string} id ID of the project.
+   * @param {object} [options] See a
+   *     [Project resource](https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project).
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Project} callback.project The created Project
+   *     object.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const {Resource} = require('@google-cloud/resource');
+   * const resource = new Resource();
+   *
+   * const id = 'new-project-id';
+   *
+   * resource.createProject(id, function(err, project, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   // `project` is a new Project instance.
+   *   // `operation` will emit `error` or `complete` when the status updates.
+   *
+   *   operation
+   *     .on('error', function(err) {})
+   *     .on('complete', function() {
+   *       // Project was created successfully!
+   *     });
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * resource.createProject(id)
+   *   .then(function(data) {
+   *     const project = data[0];
+   *     const operation = data[1];
+   *     const apiResponse = data[2];
+   *
+   *     return operation.promise();
+   *   })
+   *   .then(function(data) {
+   *     const operationMetadata = data[0];
+   *
+   *     // Project created successfully!
+   *   });
+   */
+  createProject(id, options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.request(
+      {
+        method: 'POST',
+        uri: '/projects',
+        json: extend({}, options, {
+          projectId: id,
+        }),
+      },
+      (err, resp) => {
+        if (err) {
+          callback(err, null, resp);
+          return;
+        }
+        const project = this.project(resp.projectId);
+        const operation = this.operation(resp.name);
+        operation.metadata = resp;
+        callback(null, project, operation, resp);
+      }
+    );
   };
 
-  Service.call(this, config, options);
+  /**
+   * Get a list of projects.
+   *
+   * @see [Projects Overview]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects}
+   * @see [projects: list API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/list}
+   *
+   * @param {object} [options] Operation search options.
+   * @param {boolean} [options.autoPaginate] Have pagination handled
+   *     automatically. Default: true.
+   * @param {string} [options.filter] An expression for filtering the results.
+   * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
+   * @param {number} [options.maxResults] Maximum number of results to return.
+   * @param {number} [options.pageSize] Maximum number of projects to return.
+   * @param {string} [options.pageToken] A previously-returned page token
+   *     representing part of the larger set of results to view.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Project[]} callback.operations Project objects from
+   *     your account.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const {Resource} = require('@google-cloud/resource');
+   * const resource = new Resource();
+   *
+   * resource.getProjects(function(err, projects) {
+   *   // `projects` is an array of `Project` objects.
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to `false`.
+   * //-
+   * function callback(err, projects, nextQuery, apiResponse) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     resource.getProjects(nextQuery, callback);
+   *   }
+   * }
+   *
+   * resource.getProjects({
+   *   autoPaginate: false
+   * }, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * resource.getProjects().then(function(data) {
+   *   const projects = data[0];
+   * });
+   */
+  getProjects(options, callback?) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    options = options || {};
+
+    this.request(
+      {
+        uri: '/projects',
+        qs: options,
+      },
+      (err, resp) => {
+        if (err) {
+          callback(err, null, null, resp);
+          return;
+        }
+
+        var nextQuery = null;
+
+        if (resp.nextPageToken) {
+          nextQuery = extend({}, options, {
+            pageToken: resp.nextPageToken,
+          });
+        }
+
+        var projects = (resp.projects || []).map(project => {
+          var projectInstance = this.project(project.projectId);
+          projectInstance.metadata = project;
+          return projectInstance;
+        });
+
+        callback(null, projects, nextQuery, resp);
+      }
+    );
+  };
+
+  /*! Developer Documentation
+  *
+  * @returns {module:common/operation}
+  */
+  /**
+   * Get a reference to an existing operation.
+   *
+   * @throws {Error} If a name is not provided.
+   *
+   * @param {string} name The name of the operation.
+   *
+   * @example
+   * const {Resource} = require('@google-cloud/resource');
+   * const resource = new Resource();
+   *
+   * const operation = resource.operation('68850831366825');
+   */
+  operation(name) {
+    if (!name) {
+      throw new Error('A name must be specified for an operation.');
+    }
+    return new Operation({
+      parent: this,
+      id: name,
+    });
+  };
+
+  /**
+   * Create a Project object. See {@link Resource#createProject} to create
+   * a project.
+   *
+   * @throws {Error} If an ID is not provided.
+   *
+   * @param {string} id The ID of the project (eg: `grape-spaceship-123`).
+   * @return {Project}
+   *
+   * @example
+   * const {Resource} = require('@google-cloud/resource');
+   * const resource = new Resource();
+   *
+   * const project = resource.project('grape-spaceship-123');
+   */
+  project(id?: string) {
+    id = id || this.projectId;
+    if (!id) {
+      throw new Error('A project ID is required.');
+    }
+    return new Project(this, id);
+  };
 }
 
-util.inherits(Resource, Service);
-
-/**
- * Create a project.
- *
- * **This method only works if you are authenticated as yourself, e.g. using the
- * gcloud SDK.**
- *
- * @see [Projects Overview]{@link https://cloud.google.com/compute/docs/networking#networks}
- * @see [projects: create API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/create}
- *
- * @param {string} id ID of the project.
- * @param {object} [options] See a
- *     [Project resource](https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project).
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Project} callback.project The created Project
- *     object.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Resource = require('@google-cloud/resource');
- * const resource = new Resource();
- *
- * const id = 'new-project-id';
- *
- * resource.createProject(id, function(err, project, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   // `project` is a new Project instance.
- *   // `operation` will emit `error` or `complete` when the status updates.
- *
- *   operation
- *     .on('error', function(err) {})
- *     .on('complete', function() {
- *       // Project was created successfully!
- *     });
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * resource.createProject(id)
- *   .then(function(data) {
- *     const project = data[0];
- *     const operation = data[1];
- *     const apiResponse = data[2];
- *
- *     return operation.promise();
- *   })
- *   .then(function(data) {
- *     const operationMetadata = data[0];
- *
- *     // Project created successfully!
- *   });
- */
-Resource.prototype.createProject = function(id, options, callback) {
-  var self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.request(
-    {
-      method: 'POST',
-      uri: '/projects',
-      json: extend({}, options, {
-        projectId: id,
-      }),
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, resp);
-        return;
-      }
-
-      var project = self.project(resp.projectId);
-
-      var operation = self.operation(resp.name);
-      operation.metadata = resp;
-
-      callback(null, project, operation, resp);
-    }
-  );
-};
-
-/**
- * Get a list of projects.
- *
- * @see [Projects Overview]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects}
- * @see [projects: list API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/list}
- *
- * @param {object} [options] Operation search options.
- * @param {boolean} [options.autoPaginate] Have pagination handled
- *     automatically. Default: true.
- * @param {string} [options.filter] An expression for filtering the results.
- * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
- * @param {number} [options.maxResults] Maximum number of results to return.
- * @param {number} [options.pageSize] Maximum number of projects to return.
- * @param {string} [options.pageToken] A previously-returned page token
- *     representing part of the larger set of results to view.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Project[]} callback.operations Project objects from
- *     your account.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Resource = require('@google-cloud/resource');
- * const resource = new Resource();
- *
- * resource.getProjects(function(err, projects) {
- *   // `projects` is an array of `Project` objects.
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to `false`.
- * //-
- * function callback(err, projects, nextQuery, apiResponse) {
- *   if (nextQuery) {
- *     // More results exist.
- *     resource.getProjects(nextQuery, callback);
- *   }
- * }
- *
- * resource.getProjects({
- *   autoPaginate: false
- * }, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * resource.getProjects().then(function(data) {
- *   const projects = data[0];
- * });
- */
-Resource.prototype.getProjects = function(options, callback) {
-  var self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  options = options || {};
-
-  this.request(
-    {
-      uri: '/projects',
-      qs: options,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, null, resp);
-        return;
-      }
-
-      var nextQuery = null;
-
-      if (resp.nextPageToken) {
-        nextQuery = extend({}, options, {
-          pageToken: resp.nextPageToken,
-        });
-      }
-
-      var projects = (resp.projects || []).map(function(project) {
-        var projectInstance = self.project(project.projectId);
-        projectInstance.metadata = project;
-        return projectInstance;
-      });
-
-      callback(null, projects, nextQuery, resp);
-    }
-  );
-};
-
-/**
- * Get a list of {@link Resource/project} objects as a readable object stream.
- *
- * @param {object} query Configuration object. See
- *     {@link Resource#getProjects} for a complete list of options.
- * @return {stream}
- *
- * @example
- * const Resource = require('@google-cloud/resource');
- * const resource = new Resource();
- *
- * resource.getProjectsStream()
- *   .on('error', console.error)
- *   .on('data', function(project) {
- *     // `project` is a `Project` object.
- *   })
- *   .on('end', function() {
- *     // All projects retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing and API requests.
- * //-
- * resource.getProjectsStream()
- *   .on('data', function(project) {
- *     this.end();
- *   });
- */
-Resource.prototype.getProjectsStream = paginator.streamify(
-  'getProjects'
-);
-
 /*! Developer Documentation
- *
- * @returns {module:common/operation}
- */
-/**
- * Get a reference to an existing operation.
- *
- * @throws {Error} If a name is not provided.
- *
- * @param {string} name The name of the operation.
- *
- * @example
- * const Resource = require('@google-cloud/resource');
- * const resource = new Resource();
- *
- * const operation = resource.operation('68850831366825');
- */
-Resource.prototype.operation = function(name) {
-  if (!name) {
-    throw new Error('A name must be specified for an operation.');
-  }
-
-  return new Operation({
-    parent: this,
-    id: name,
-  });
-};
-
-/**
- * Create a Project object. See {@link Resource#createProject} to create
- * a project.
- *
- * @throws {Error} If an ID is not provided.
- *
- * @param {string} id The ID of the project (eg: `grape-spaceship-123`).
- * @return {Project}
- *
- * @example
- * const Resource = require('@google-cloud/resource');
- * const resource = new Resource();
- *
- * const project = resource.project('grape-spaceship-123');
- */
-Resource.prototype.project = function(id) {
-  id = id || this.projectId;
-
-  if (!id) {
-    throw new Error('A project ID is required.');
-  }
-
-  return new Project(this, id);
-};
-
-/*! Developer Documentation
- *
- * These methods can be auto-paginated.
- */
+*
+* These methods can be auto-paginated.
+*/
 paginator.extend(Resource, ['getProjects']);
 
 /*! Developer Documentation
- *
- * All async methods (except for streams) will return a Promise in the event
- * that a callback is omitted.
- */
+*
+* All async methods (except for streams) will return a Promise in the event
+* that a callback is omitted.
+*/
 promisifyAll(Resource, {
   exclude: ['operation', 'project'],
 });
@@ -385,7 +372,7 @@ promisifyAll(Resource, {
  * @see Project
  * @type {constructor}
  */
-(Resource as any).Project = Project;
+export {Project};
 
 /**
  * The default export of the `@google-cloud/resource` package is the
@@ -401,7 +388,7 @@ promisifyAll(Resource, {
  * npm install --save @google-cloud/resource
  *
  * @example <caption>Import the client library</caption>
- * const Resource = require('@google-cloud/resource');
+ * const {Resource} = require('@google-cloud/resource');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const resource = new Resource();
@@ -416,4 +403,4 @@ promisifyAll(Resource, {
  * region_tag:resource_quickstart
  * Full quickstart example:
  */
-module.exports = Resource;
+export {Resource};

--- a/src/project.ts
+++ b/src/project.ts
@@ -16,9 +16,9 @@
 
 'use strict';
 
-import * as common from '@google-cloud/common';
+import {util, ServiceObject} from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
-import * as util from 'util';
+import { Resource } from '.';
 
 /**
  * A Project object allows you to interact with a Google Cloud Platform project.
@@ -31,286 +31,286 @@ import * as util from 'util';
  * @param {string} id The project's ID.
  *
  * @example
- * const Resource = require('@google-cloud/resource');
+ * const {Resource} = require('@google-cloud/resource');
  * const resource = new Resource();
  * const project = resource.project('grape-spaceship-123');
  */
-function Project(resource, id) {
-  var methods = {
-    /**
-     * Create a project.
-     *
-     * @method Project#create
-     * @param {object} [config] See {@link Resource#createProject}.
-     *
-     * @example
-     * const Resource = require('@google-cloud/resource');
-     * const resource = new Resource();
-     * const project = resource.project('grape-spaceship-123');
-     *
-     * project.create(function(err, project, operation, apiResponse) {
-     *   if (err) {
-     *     // Error handling omitted.
-     *   }
-     *
-     *   // `operation` will emit `error` or `complete` when the status updates.
-     *
-     *   operation
-     *     .on('error', function(err) {})
-     *     .on('complete', function() {
-     *       // Project was created successfully!
-     *     });
-     * });
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * project.create()
-     *   .then(function(data) {
-     *     const project = data[0];
-     *     const operation = data[1];
-     *     const apiResponse = data[2];
-     *
-     *     return operation.promise();
-     *   })
-     *   .then(function(data) {
-     *     const operationMetadata = data[0];
-     *
-     *     // Project created successfully!
-     *   });
-     */
-    create: true,
+class Project extends ServiceObject {
+  constructor(resource: Resource, id: string) {
+    var methods = {
+      /**
+       * Create a project.
+       *
+       * @method Project#create
+       * @param {object} [config] See {@link Resource#createProject}.
+       *
+       * @example
+       * const {Resource} = require('@google-cloud/resource');
+       * const resource = new Resource();
+       * const project = resource.project('grape-spaceship-123');
+       *
+       * project.create(function(err, project, operation, apiResponse) {
+       *   if (err) {
+       *     // Error handling omitted.
+       *   }
+       *
+       *   // `operation` will emit `error` or `complete` when the status updates.
+       *
+       *   operation
+       *     .on('error', function(err) {})
+       *     .on('complete', function() {
+       *       // Project was created successfully!
+       *     });
+       * });
+       *
+       * //-
+       * // If the callback is omitted, we'll return a Promise.
+       * //-
+       * project.create()
+       *   .then(function(data) {
+       *     const project = data[0];
+       *     const operation = data[1];
+       *     const apiResponse = data[2];
+       *
+       *     return operation.promise();
+       *   })
+       *   .then(function(data) {
+       *     const operationMetadata = data[0];
+       *
+       *     // Project created successfully!
+       *   });
+       */
+      create: true,
 
-    /**
-     * Delete the project.
-     *
-     * **This method only works if you are authenticated as yourself, e.g. using
-     * the gcloud SDK.**
-     *
-     * @see [projects: delete API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/delete}
-     *
-     * @method Project#delete
-     * @param {function} [callback] The callback function.
-     * @param {?error} callback.err An error returned while making this
-     *     request.
-     * @param {object} callback.apiResponse The full API response.
-     *
-     * @example
-     * const Resource = require('@google-cloud/resource');
-     * const resource = new Resource();
-     * const project = resource.project('grape-spaceship-123');
-     *
-     * project.delete(function(err, apiResponse) {
-     *   if (!err) {
-     *     // The project was deleted!
-     *   }
-     * });
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * project.delete().then(function(data) {
-     *   const apiResponse = data[0];
-     * });
-     */
-    delete: true,
+      /**
+       * Delete the project.
+       *
+       * **This method only works if you are authenticated as yourself, e.g. using
+       * the gcloud SDK.**
+       *
+       * @see [projects: delete API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/delete}
+       *
+       * @method Project#delete
+       * @param {function} [callback] The callback function.
+       * @param {?error} callback.err An error returned while making this
+       *     request.
+       * @param {object} callback.apiResponse The full API response.
+       *
+       * @example
+       * const {Resource} = require('@google-cloud/resource');
+       * const resource = new Resource();
+       * const project = resource.project('grape-spaceship-123');
+       *
+       * project.delete((err, apiResponse) => {
+       *   if (!err) {
+       *     // The project was deleted!
+       *   }
+       * });
+       *
+       * //-
+       * // If the callback is omitted, we'll return a Promise.
+       * //-
+       * project.delete().then((data) => {
+       *   const apiResponse = data[0];
+       * });
+       */
+      delete: true,
 
-    /**
-     * Check if the project exists.
-     *
-     * @param {function} callback The callback function.
-     * @param {?error} callback.err An error returned while making this
-     *     request.
-     * @param {boolean} callback.exists Whether the project exists or not.
-     *
-     * @example
-     * const Resource = require('@google-cloud/resource');
-     * const resource = new Resource();
-     * const project = resource.project('grape-spaceship-123');
-     *
-     * project.exists(function(err, exists) {});
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * project.exists().then(function(data) {
-     *   const exists = data[0];
-     * });
-     */
-    exists: true,
+      /**
+       * Check if the project exists.
+       *
+       * @param {function} callback The callback function.
+       * @param {?error} callback.err An error returned while making this
+       *     request.
+       * @param {boolean} callback.exists Whether the project exists or not.
+       *
+       * @example
+       * const {Resource} = require('@google-cloud/resource');
+       * const resource = new Resource();
+       * const project = resource.project('grape-spaceship-123');
+       *
+       * project.exists((err, exists) => {});
+       *
+       * //-
+       * // If the callback is omitted, we'll return a Promise.
+       * //-
+       * project.exists().then((data) => {
+       *   const exists = data[0];
+       * });
+       */
+      exists: true,
 
-    /**
-     * Get a project if it exists.
-     *
-     * You may optionally use this to "get or create" an object by providing an
-     * object with `autoCreate` set to `true`. Any extra configuration that is
-     * normally required for the `create` method must be contained within this
-     * object as well.
-     *
-     * @method Project#get
-     * @param {options} [options] Configuration object.
-     * @param {boolean} [options.autoCreate=false] Automatically create the
-     *     object if it does not exist.
-     *
-     * @example
-     * const Resource = require('@google-cloud/resource');
-     * const resource = new Resource();
-     * const project = resource.project('grape-spaceship-123');
-     *
-     * project.get(function(err, project, apiResponse) {
-     *   // `project.metadata` has been populated.
-     * });
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * project.get().then(function(data) {
-     *   const project = data[0];
-     *   const apiResponse = data[1];
-     * });
-     */
-    get: true,
+      /**
+       * Get a project if it exists.
+       *
+       * You may optionally use this to "get or create" an object by providing an
+       * object with `autoCreate` set to `true`. Any extra configuration that is
+       * normally required for the `create` method must be contained within this
+       * object as well.
+       *
+       * @method Project#get
+       * @param {options} [options] Configuration object.
+       * @param {boolean} [options.autoCreate=false] Automatically create the
+       *     object if it does not exist.
+       *
+       * @example
+       * const {Resource} = require('@google-cloud/resource');
+       * const resource = new Resource();
+       * const project = resource.project('grape-spaceship-123');
+       *
+       * project.get((err, project, apiResponse) => {
+       *   // `project.metadata` has been populated.
+       * });
+       *
+       * //-
+       * // If the callback is omitted, we'll return a Promise.
+       * //-
+       * project.get().then((data) => {
+       *   const project = data[0];
+       *   const apiResponse = data[1];
+       * });
+       */
+      get: true,
 
-    /**
-     * Get the metadata for the project.
-     *
-     * @see [projects: get API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/get}
-     *
-     * @method Project#getMetadata
-     * @param {function} [callback] The callback function.
-     * @param {?error} callback.err An error returned while making this
-     *     request.
-     * @param {?object} callback.metadata - Metadata of the project from the
-     *     API.
-     * @param {object} callback.apiResponse - Raw API response.
-     *
-     * @example
-     * const Resource = require('@google-cloud/resource');
-     * const resource = new Resource();
-     * const project = resource.project('grape-spaceship-123');
-     *
-     * project.getMetadata(function(err, metadata, apiResponse) {});
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * project.getMetadata().then(function(data) {
-     *   const metadata = data[0];
-     *   const apiResponse = data[1];
-     * });
-     */
-    getMetadata: true,
+      /**
+       * Get the metadata for the project.
+       *
+       * @see [projects: get API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/get}
+       *
+       * @method Project#getMetadata
+       * @param {function} [callback] The callback function.
+       * @param {?error} callback.err An error returned while making this
+       *     request.
+       * @param {?object} callback.metadata - Metadata of the project from the
+       *     API.
+       * @param {object} callback.apiResponse - Raw API response.
+       *
+       * @example
+       * const {Resource} = require('@google-cloud/resource');
+       * const resource = new Resource();
+       * const project = resource.project('grape-spaceship-123');
+       *
+       * project.getMetadata((err, metadata, apiResponse) => {});
+       *
+       * //-
+       * // If the callback is omitted, we'll return a Promise.
+       * //-
+       * project.getMetadata().then((data) => {
+       *   const metadata = data[0];
+       *   const apiResponse = data[1];
+       * });
+       */
+      getMetadata: true,
 
-    /**
-     * Set the project's metadata.
-     *
-     * **This method only works if you are authenticated as yourself, e.g. using
-     * the gcloud SDK.**
-     *
-     * @see [projects: update API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/update}
-     * @see [Project Resource]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project}
-     *
-     * @method Project#setMetadata
-     * @param {object} metadata See a
-     *     [Project resource](https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project).
-     * @param {function} [callback] The callback function.
-     * @param {?error} callback.err An error returned while making this
-     *     request.
-     * @param {object} callback.apiResponse The full API response.
-     *
-     * @example
-     * const Resource = require('@google-cloud/resource');
-     * const resource = new Resource();
-     * const project = resource.project('grape-spaceship-123');
-     *
-     * const metadata = {
-     *   name: 'New name'
-     * };
-     *
-     * project.setMetadata(metadata, function(err, apiResponse) {
-     *   if (!err) {
-     *     // The project has been successfully updated.
-     *   }
-     * });
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * project.setMetadata(metadata).then(function(data) {
-     *   const apiResponse = data[0];
-     * });
-     */
-    setMetadata: {
-      reqOpts: {
-        method: 'PUT',
+      /**
+       * Set the project's metadata.
+       *
+       * **This method only works if you are authenticated as yourself, e.g. using
+       * the gcloud SDK.**
+       *
+       * @see [projects: update API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/update}
+       * @see [Project Resource]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project}
+       *
+       * @method Project#setMetadata
+       * @param {object} metadata See a
+       *     [Project resource](https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project).
+       * @param {function} [callback] The callback function.
+       * @param {?error} callback.err An error returned while making this
+       *     request.
+       * @param {object} callback.apiResponse The full API response.
+       *
+       * @example
+       * const {Resource} = require('@google-cloud/resource');
+       * const resource = new Resource();
+       * const project = resource.project('grape-spaceship-123');
+       *
+       * const metadata = {
+       *   name: 'New name'
+       * };
+       *
+       * project.setMetadata(metadata, (err, apiResponse) => {
+       *   if (!err) {
+       *     // The project has been successfully updated.
+       *   }
+       * });
+       *
+       * //-
+       * // If the callback is omitted, we'll return a Promise.
+       * //-
+       * project.setMetadata(metadata).then((data) => {
+       *   const apiResponse = data[0];
+       * });
+       */
+      setMetadata: {
+        reqOpts: {
+          method: 'PUT',
+        },
       },
-    },
-  };
+    };
 
-  common.ServiceObject.call(this, {
-    parent: resource,
-    baseUrl: '/projects',
-    /**
-     * @name Project#id
-     * @type {string}
-     */
-    id: id,
-    createMethod: resource.createProject.bind(resource),
-    methods: methods,
-  });
+    super({
+      parent: resource,
+      baseUrl: '/projects',
+      /**
+       * @name Project#id
+       * @type {string}
+       */
+      id: id,
+      createMethod: resource.createProject.bind(resource),
+      methods: methods,
+    } as any);
+  }
+
+  /**
+   * Restore a project.
+   *
+   * **This method only works if you are authenticated as yourself, e.g. using the
+   * gcloud SDK.**
+   *
+   * @see [projects: undelete API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/undelete}
+   *
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse Raw API response.
+   *
+   * @example
+   * const {Resource} = require('@google-cloud/resource');
+   * const resource = new Resource();
+   * const project = resource.project('grape-spaceship-123');
+   *
+   * project.restore((err, apiResponse) => {
+   *   if (!err) {
+   *     // Project restored.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * project.restore().then((data) => {
+   *   const apiResponse = data[0];
+   * });
+   */
+  restore(callback) {
+    callback = callback || util.noop;
+
+    this.request(
+      {
+        method: 'POST',
+        uri: ':undelete',
+      },
+      (err, resp) => {
+        callback(err, resp);
+      }
+    );
+  };
 }
 
-util.inherits(Project, common.ServiceObject);
-
-/**
- * Restore a project.
- *
- * **This method only works if you are authenticated as yourself, e.g. using the
- * gcloud SDK.**
- *
- * @see [projects: undelete API Documentation]{@link https://cloud.google.com/resource-manager/reference/rest/v1/projects/undelete}
- *
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse Raw API response.
- *
- * @example
- * const Resource = require('@google-cloud/resource');
- * const resource = new Resource();
- * const project = resource.project('grape-spaceship-123');
- *
- * project.restore(function(err, apiResponse) {
- *   if (!err) {
- *     // Project restored.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * project.restore().then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Project.prototype.restore = function(callback) {
-  callback = callback || common.util.noop;
-
-  this.request(
-    {
-      method: 'POST',
-      uri: ':undelete',
-    },
-    function(err, resp) {
-      callback(err, resp);
-    }
-  );
-};
-
 /*! Developer Documentation
- *
- * All async methods (except for streams) will return a Promise in the event
- * that a callback is omitted.
- */
+*
+* All async methods (except for streams) will return a Promise in the event
+* that a callback is omitted.
+*/
 promisifyAll(Project);
 
 /**
@@ -318,4 +318,4 @@ promisifyAll(Project);
  * @name module:@google-cloud/resource.Project
  * @see Project
  */
-module.exports = Project;
+export {Project};

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,8 +88,10 @@ describe('Resource', function() {
       },
       '@google-cloud/promisify': fakePromisify,
       '@google-cloud/paginator': fakePaginator,
-      './project': FakeProject,
-    });
+      './project': {
+        Project: FakeProject,
+      }
+    }).Resource;
   });
 
   beforeEach(function() {
@@ -137,7 +139,7 @@ describe('Resource', function() {
     var OPTIONS = {a: 'b', c: 'd'};
     var EXPECTED_BODY = extend({}, OPTIONS, {projectId: NEW_PROJECT_ID});
 
-    it('should not require any options', function(done) {
+    it('should not require any options', done => {
       var expectedBody = {projectId: NEW_PROJECT_ID};
 
       resource.request = function(reqOpts) {
@@ -148,7 +150,7 @@ describe('Resource', function() {
       resource.createProject(NEW_PROJECT_ID, assert.ifError);
     });
 
-    it('should make the correct API request', function(done) {
+    it('should make the correct API request', done => {
       resource.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/projects');
@@ -170,7 +172,7 @@ describe('Resource', function() {
         };
       });
 
-      it('should execute callback with error & API response', function(done) {
+      it('should execute callback with error & API response', done => {
         resource.createProject(NEW_PROJECT_ID, OPTIONS, function(err, p, res) {
           assert.strictEqual(err, error);
           assert.strictEqual(p, null);
@@ -191,7 +193,7 @@ describe('Resource', function() {
         };
       });
 
-      it('should exec callback with Project & API response', function(done) {
+      it('should exec callback with Project & API response', done => {
         var project = {};
         var fakeOperation = {};
 
@@ -222,7 +224,7 @@ describe('Resource', function() {
   });
 
   describe('getProjects', function() {
-    it('should accept only a callback', function(done) {
+    it('should accept only a callback', done => {
       resource.request = function(reqOpts) {
         assert.deepStrictEqual(reqOpts.qs, {});
         done();
@@ -231,7 +233,7 @@ describe('Resource', function() {
       resource.getProjects(assert.ifError);
     });
 
-    it('should make the correct API request', function(done) {
+    it('should make the correct API request', done => {
       var query = {a: 'b', c: 'd'};
 
       resource.request = function(reqOpts) {
@@ -254,7 +256,7 @@ describe('Resource', function() {
         };
       });
 
-      it('should execute callback with error & API response', function(done) {
+      it('should execute callback with error & API response', done => {
         resource.getProjects({}, function(err, projects, nextQuery, apiResp) {
           assert.strictEqual(err, error);
           assert.strictEqual(projects, null);
@@ -276,7 +278,7 @@ describe('Resource', function() {
         };
       });
 
-      it('should build a nextQuery if necessary', function(done) {
+      it('should build a nextQuery if necessary', done => {
         var nextPageToken = 'next-page-token';
         var apiResponseWithNextPageToken = extend({}, apiResponse, {
           nextPageToken: nextPageToken,
@@ -298,7 +300,7 @@ describe('Resource', function() {
         });
       });
 
-      it('should execute callback with Projects & API resp', function(done) {
+      it('should execute callback with Projects & API resp', done => {
         var project = {};
 
         resource.project = function(name) {


### PR DESCRIPTION
BREAKING CHANGE: The import syntax for this library has changed to be [es module](https://nodejs.org/api/esm.html) compliant. 

### Old code
```js
const resource = require('@google-cloud/resource')();
// or 
const Resource = require('@google-cloud/resource');
const resource = new Resource();
```

### New code
```js
const {Resource} = require('@google-cloud/resource');
const resource = new Resource();
```
