### PR TITLE
refactor(samples): convert sample tests from ava to mocha

### DIFF
--- a/samples/.eslintrc.yml
+++ b/samples/.eslintrc.yml
@@ -1,3 +1,5 @@
 ---
+env:
+  mocha: true
 rules:
   no-console: off

--- a/samples/package.json
+++ b/samples/package.json
@@ -10,7 +10,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "ava -T 20s --verbose system-test/*.test.js"
+    "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
     "@google-cloud/resource": "^0.8.1",

--- a/samples/system-test/projects.test.js
+++ b/samples/system-test/projects.test.js
@@ -15,17 +15,17 @@
 
 'use strict';
 
-const path = require(`path`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
-const cwd = path.join(__dirname, `..`);
-const cmd = `node projects.js`;
+const cwd = path.join(__dirname, '..');
+const cmd = 'node projects.js';
 
 before(tools.checkCredentials);
 
-it(`should list projects`, async () => {
+it('should list projects', async () => {
   const output = await tools.runAsync(`${cmd} list`, cwd);
-  assert.ok(output.includes(`Projects:`));
+  assert.ok(output.includes('Projects:'));
   assert.ok(output.includes(`${process.env.GCLOUD_PROJECT}`));
 });

--- a/samples/system-test/projects.test.js
+++ b/samples/system-test/projects.test.js
@@ -16,16 +16,16 @@
 'use strict';
 
 const path = require(`path`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 
 const cwd = path.join(__dirname, `..`);
 const cmd = `node projects.js`;
 
-test.before(tools.checkCredentials);
+before(tools.checkCredentials);
 
-test(`should list projects`, async t => {
+it(`should list projects`, async () => {
   const output = await tools.runAsync(`${cmd} list`, cwd);
-  t.true(output.includes(`Projects:`));
-  t.true(output.includes(`${process.env.GCLOUD_PROJECT}`));
+  assert.ok(output.includes(`Projects:`));
+  assert.ok(output.includes(`${process.env.GCLOUD_PROJECT}`));
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -16,33 +16,27 @@
 'use strict';
 
 const proxyquire = require(`proxyquire`).noPreserveCache();
-const Resource = proxyquire(`@google-cloud/resource`, {}).Resource;
+const Resource = proxyquire(`@google-cloud/resource`, {});
 const sinon = require(`sinon`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 
 const resource = new Resource();
 
-test.before(tools.stubConsole);
-test.after.always(tools.restoreConsole);
+before(tools.stubConsole);
+after(tools.restoreConsole);
 
-test.cb(`should list projects`, t => {
+it(`should list projects`, () => {
   const resourceMock = {
-    getProjects: () => {
-      return resource.getProjects().then(([projects]) => {
-        t.true(Array.isArray(projects));
-        setTimeout(() => {
-          try {
-            t.true(console.log.called);
-            t.deepEqual(console.log.firstCall.args, [`Projects:`]);
-            projects.forEach((project, i) => {
-              t.deepEqual(console.log.getCall(i + 1).args, [project.id]);
-            });
-            t.end();
-          } catch (err) {
-            t.end(err);
-          }
-        }, 200);
+    getProjects: async () => {
+      return await resource.getProjects().then(async ([projects]) => {
+        assert.ok(Array.isArray(projects));
+        await new Promise(r => setTimeout(r, 200));
+        assert.ok(console.log.called);
+        assert.deepStrictEqual(console.log.firstCall.args, [`Projects:`]);
+        projects.map((project, i) =>
+          assert.deepStrictEqual(console.log.getCall(i + 1).args, [project.id])
+        );
 
         return [projects];
       });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -15,25 +15,25 @@
 
 'use strict';
 
-const proxyquire = require(`proxyquire`).noPreserveCache();
-const Resource = proxyquire(`@google-cloud/resource`, {});
-const sinon = require(`sinon`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const proxyquire = require('proxyquire').noPreserveCache();
+const Resource = proxyquire('@google-cloud/resource', {});
+const sinon = require('sinon');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
 const resource = new Resource();
 
 before(tools.stubConsole);
 after(tools.restoreConsole);
 
-it(`should list projects`, () => {
+it('should list projects', () => {
   const resourceMock = {
     getProjects: async () => {
       return await resource.getProjects().then(async ([projects]) => {
         assert.ok(Array.isArray(projects));
         await new Promise(r => setTimeout(r, 200));
         assert.ok(console.log.called);
-        assert.deepStrictEqual(console.log.firstCall.args, [`Projects:`]);
+        assert.deepStrictEqual(console.log.firstCall.args, ['Projects:']);
         projects.map((project, i) =>
           assert.deepStrictEqual(console.log.getCall(i + 1).args, [project.id])
         );
@@ -43,7 +43,7 @@ it(`should list projects`, () => {
     },
   };
 
-  proxyquire(`../quickstart`, {
+  proxyquire('../quickstart', {
     '@google-cloud/resource': {
       Resource: sinon.stub().returns(resourceMock),
     },


### PR DESCRIPTION
Fixes convert all sample tests from ava to mocha [#2865](https://github.com/googleapis/google-cloud-node/issues/2865) (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
